### PR TITLE
Update Dockerfile to Fix Permission

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,9 @@ RUN \
 
 COPY container-files /
 
+## Added to correct permissions when building locally on Windows Environment
+RUN chmod +x /bootstrap.sh
+
 WORKDIR /workdir
 
 ENTRYPOINT ["/bootstrap.sh"]


### PR DESCRIPTION
Building on Windows with Linux containers fails to execute because the script permissions are broken.